### PR TITLE
fix: (defconstant quote 3) causes constant declaring the cl:quote

### DIFF
--- a/read-csv.lisp
+++ b/read-csv.lisp
@@ -23,6 +23,7 @@
 
 (defpackage :read-csv
   (:use :common-lisp)
+  (:shadow :quote)
   (:export read-csv parse-csv))
 
 (in-package :read-csv)

--- a/test.lisp
+++ b/test.lisp
@@ -190,6 +190,13 @@ multiline\", data")
 (deftest test-multiline-dos   (multiline-dos-example)   *multiline-answer*)
 (deftest test-multiline-mixed (multiline-mixed-example) *multiline-answer*)
 
+(defun misc-tests ()
+  (handler-case (eval '(let ((quote 'cl:quote))
+                        (declare (ignore quote))
+                        :ok))
+    (error () :fail)))
+
+(deftest test-misc-tests (misc-tests) :ok)
 
 (defstruct results
   (tests 0)
@@ -238,7 +245,8 @@ multiline\", data")
                  #'test-quoted-big
                  #'test-multiline-unix
                  #'test-multiline-dos
-                 #'test-multiline-mixed)
+                 #'test-multiline-mixed
+                 #'test-misc-tests)
            :initial-value starting-results))
   
 (defun run-tests ()


### PR DESCRIPTION
(defconstant quote 3) causes constant declaring the cl:quote (in SBCL).
Some Quicklisp projects using the cl:quote as a variable name and it will be their build will fail.

;;; before loading
(compile nil '(lambda (cl:quote) (setq cl:quote 3)))
; compiling (COMPILE NIL ...)

;;; loading
(asdf:load-system :read-csv)

;;; after loading. 
(compile nil '(lambda (cl:quote) (setq cl:quote 3)))
; compiling (COMPILE NIL ...); in: LAMBDA (QUOTE)
;     (LAMBDA (QUOTE) (SETQ QUOTE 3))
; 
; caught ERROR:
;   QUOTE names a defined constant, and cannot be used as a local variable.
; 
; compilation unit finished
;   caught 1 ERROR condition
