### PR TITLE
Ensure the initial value of +csv-table+ is evaluated at both compile time and load time.

### DIFF
--- a/read-csv.lisp
+++ b/read-csv.lisp
@@ -33,7 +33,7 @@
 (defconstant q+q&w 6)  ;; Quoted and have seen quote, in following whitespace
 
 (defconstant +csv-table+
-  (if (boundp '+csv-table+) +csv-table+
+  (if (boundp '+csv-table+) (symbol-value '+csv-table+)
       (make-array '(7 6 2) 
        :initial-contents
        ;;WHITE,         RETURN,       LF,           QUOTE,        SEP,          OTHER           ;; STATE 


### PR DESCRIPTION
read-csv fails build with LispWorks...

> Error: The variable +csv-table+ is unbound.

and CLHS says...

http://www.lispworks.com/documentation/HyperSpec/Body/m_defcon.htm

> If a defconstant form appears as a top level form, the compiler must recognize that name names a constant variable. An implementation may choose to evaluate the value-form at compile time, load time, or both. Therefore, users must ensure that the initial-value can be evaluated at compile time (regardless of whether or not references to name appear in the file) and that it always evaluates to the same value. 

and LispWorks evaluate the value-form at load time.

Thus, for portability, must ensure that the initial value of +csv-table+ can be evaluated at both compile time and load time.