### PR TITLE
Fix ASDF warning: rename read-csv.test to read-csv/test (#8)

### DIFF
--- a/read-csv.asd
+++ b/read-csv.asd
@@ -5,16 +5,16 @@
   :license "cc0 (public domain)"
   :description "A library for reading CSV data from streams."
   :components ((:file "read-csv"))
-  :in-order-to ((test-op (load-op read-csv.test))))
+  :in-order-to ((test-op (load-op "read-csv/test"))))
 
-(defsystem :read-csv.test
-  :name "read-csv.test"
+(defsystem "read-csv/test"
+  :name "read-csv/test"
   :version "1.0.2"
   :author "Warren Wilkinson <warrenwilkinson@gmail.com>"
   :description "Testing code for the read-csv library"
-  :licence "cc0 (public domain)"
+  :license "cc0 (public domain)"
   :depends-on (:read-csv)
   :components ((:file "test")))
-    
-(defmethod perform ((op asdf:test-op) (system (eql (find-system :read-csv))))
-  (funcall (intern "RUN-TESTS" :read-csv.test)))
+
+(defmethod perform ((op asdf:test-op) (system (eql (find-system "read-csv"))))
+  (funcall (intern "RUN-TESTS" "READ-CSV.TEST")))


### PR DESCRIPTION
Changed ASDF system name from read-csv.test to read-csv/test as per ASDF's conventions, and as a warning mentioned in the issue said should be done. (Note that the package name read-csv.test remains as is. Not sure if *that's* inconsistent, but if it is, that would be a separate issue.)